### PR TITLE
Update openapi.yaml to make sure ending_at is always serialized in request

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -13747,6 +13747,7 @@ components:
             \ Universal Time (UTC)."
           example: 2022-10-08T00:00:00Z
           format: date-time
+          nullable: true
           type: string
         subscription_at:
           description: The start date and time of the subscription. This field can
@@ -13758,6 +13759,8 @@ components:
           type: string
         plan_overrides:
           $ref: '#/components/schemas/PlanOverridesObject'
+      required:
+      - subscription_at
       type: object
     TaxCreateInput_tax:
       allOf:


### PR DESCRIPTION
Imagine you are updating a subscription and want to remove the `ends_at` date.

Right now this doesn't work correctly: Settings `ends_at` to null in Java code will omit `ends_at` from the request all together.
The cause is that generated client specifies `@JsonInclude(Include.USE_DEFAULTS)` on the field, which will by default omit any null values from the request.

We need to override this for this specific field. Setting it to required in the spec will change the annotation to `@JsonInclude(Include.ALWAYS)` , which will cause it be serialised in the request, even if it's value is null.

Note: I realise this openapi.yaml might not be your master file, but then please propagate the fix accordingly.